### PR TITLE
Pairクラスの実装

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,3 +1,5 @@
+case class Pair[A, B](a: A, b: B)
+
 object Main {
 
 }


### PR DESCRIPTION
プルリクエストの練習なので、マージは不要です

REPLでの表示がテキストと異なり、Pair型ではなくタプルとして表示されています

scala> Pair(1, "a")
warning: there was one deprecation warning (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
res0: (Int, String) = (1,a)